### PR TITLE
Support forward slash on branch name

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -36,8 +36,12 @@ if ($debug) { $debug_log .= "Repo name: $repo_name\n";}
 if ($debug) { $debug_log .= "Repo filename: $repo_filename\n";}
 
 
-$unique_id = uniqid($action . '_' . str_replace('/', '-', $repo) . '_' . str_replace('/', '-', $branch) . '_' . str_replace('/', '-', $directory) . '_');
-if ($debug) { $debug_log .= "Unique id: $unique_id\n";}
+$concatenated = $repo . '_' . $branch . '_' . $directory;
+$normalized = str_replace('/', '-', $concatenated);
+
+$unique_id = uniqid($action . '_' . $normalized . '_');
+
+if ($debug) { $debug_log .= "Unique id: $unique_id\n"; }
 
 switch ($action) {
   case 'archive':

--- a/proxy.php
+++ b/proxy.php
@@ -19,7 +19,8 @@ if (!$repo) {
   die('Repo required');
 }
 
-$repo_name = end(explode('/', $repo));
+$repo_name = explode('/', $repo);
+$repo_name = end($repo_name);
 
 if (!$branch) {
   $branch = getDefaultBranch($repo);
@@ -35,7 +36,7 @@ if ($debug) { $debug_log .= "Repo name: $repo_name\n";}
 if ($debug) { $debug_log .= "Repo filename: $repo_filename\n";}
 
 
-$unique_id = uniqid($action . '_' . str_replace('/', '-', $repo) . '_' . $branch . '_' . str_replace('/', '-', $directory) . '_');
+$unique_id = uniqid($action . '_' . str_replace('/', '-', $repo) . '_' . str_replace('/', '-', $branch) . '_' . str_replace('/', '-', $directory) . '_');
 if ($debug) { $debug_log .= "Unique id: $unique_id\n";}
 
 switch ($action) {


### PR DESCRIPTION
Using branches with forward slashes in their names causes two problems:
1. Log files are not created, because the script tries to create the log file in a subdirectory.
2. The script fails to checkout versions other than the initial checked out one because the initial checkout directory is not empty on subsequent tries. It also fails to create temp directories. Tested with branch name `add/playground-theme-preview`

```
[Fri Apr 19 14:10:46 2024] PHP Warning:  mkdir(): No such file or directory in /Users/vcanales/dev/github-proxy/proxy.php on line 66
[Fri Apr 19 14:10:46 2024] PHP Warning:  chdir(): No such file or directory (errno 2) in /Users/vcanales/dev/github-proxy/proxy.php on line 67
fatal: destination path 'themes' already exists and is not an empty directory.
```
This also creates a corrupt .zip file:

<img width="1183" alt="image" src="https://github.com/stoph/github-proxy/assets/1157901/d81a9b9f-9310-4dd1-a883-11a3ce650bfc">
