### PR TITLE
Allow to use the 'latest' release 

### DIFF
--- a/proxy/index.php
+++ b/proxy/index.php
@@ -165,7 +165,7 @@ switch ($action) {
         break;
       case 'release':
         if ($asset) {
-          $url = "https://github.com/$repo/releases/download/$release/$asset";
+          $url = ( 'latest' === $release ) ? "https://github.com/$repo/releases/$release/download/$asset" : "https://github.com/$repo/releases/download/$release/$asset";
         } else {
           $url = "https://github.com/$repo/archive/refs/tags/$release.zip";
         }


### PR DESCRIPTION
Hopefully this fixes https://github.com/stoph/github-proxy/issues/9 and allows to use a _latest_ release.